### PR TITLE
ViMusic: Fix Compilation as per Android 14 QPR2

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -6,5 +6,6 @@ android_app_import {
 	dex_preopt: {
 		enabled: false,
 	},
+        preprocessed: true,
 	product_specific: true,
 }


### PR DESCRIPTION
* packages/apps/ViMusic/vimusic-0.5.4.apk: Prebuilt, presigned apks with targetSdkVersion >= 30 (or a codename targetSdkVersion) must set preprocessed: true in the Android.bp definition (because they must be signed with signature v2, and the build system would wreck that signature otherwise)